### PR TITLE
Persist optional additional scan file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: KISS Plugins
 Tags: woocommerce, shipping, export, csv, shipping zones, shipping methods, backup, audit, simple  
 Requires at least: 6.0  
 Tested up to: 6.8  
-Stable tag: 1.0.7  
+Stable tag: 1.0.8
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -190,8 +190,9 @@ To keep the admin fast and responsive on stores with many zones/methods. The CSV
 
 See `changelog.md` for detailed version history. Highlights:
 
-- **1.0.7** – Fixed zone warning; cleaner price text; refined method details.  
-- **1.0.6** – Restored Zones & Methods Preview with filters, warnings, and deep links.  
+- **1.0.8** – Remembers the additional theme file to scan for custom rules.
+- **1.0.7** – Fixed zone warning; cleaner price text; refined method details.
+- **1.0.6** – Restored Zones & Methods Preview with filters, warnings, and deep links.
 - **1.0.5+** – Improved human-readable AST summaries; security hardening; realpath clamping; parser self-test.
 
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.8
+* **Enhancement:** Remembers the optional additional file to scan by saving it in the database.
+
 ## 1.0.7
 * **Fix:** Eliminated "Undefined array key zone_id" by iterating zone IDs (and explicitly adding zone ID 0 for Rest of World).
 * **UX:** Price outputs in the Zones & Methods preview now render as clean text (no Woo price HTML).

--- a/kiss-woo-shipping-settings-debugger.php
+++ b/kiss-woo-shipping-settings-debugger.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: KISS Woo Shipping Settings Debugger
  * Description: Exports UI-based WooCommerce shipping settings and scans theme files for custom shipping rules via AST.
- * Version:     1.0.7
+ * Version:     1.0.8
  * Author:      KISS Plugins
  * Requires at least: 6.0
  * Requires PHP: 7.4
@@ -96,8 +96,12 @@ class KISS_WSE_Debugger {
      * Output the main admin page with scan and export options.
      */
     public function render_page(): void {
-        $additional = $_GET['wse_additional_file'] ?? '';
-        $additional = sanitize_text_field( wp_unslash( $additional ) );
+        if ( isset( $_GET['wse_additional_file'] ) ) {
+            $additional = sanitize_text_field( wp_unslash( $_GET['wse_additional_file'] ) );
+            update_option( 'kiss_wse_additional_file', $additional );
+        } else {
+            $additional = sanitize_text_field( (string) get_option( 'kiss_wse_additional_file', '' ) );
+        }
 
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'KISS Woo Shipping Settings Debugger & Scanner', 'kiss-woo-shipping-debugger' ) . '</h1>';


### PR DESCRIPTION
## Summary
- Remember additional theme file to scan by storing it in the database
- Bump plugin version to 1.0.8 and update documentation

## Testing
- `php -l kiss-woo-shipping-settings-debugger.php`


------
https://chatgpt.com/codex/tasks/task_b_688d8bd21428832e8715f760fb925dbb