### PR TITLE
Add functional grouping toggle to shipping scanner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.0
+* **Feature:** Added a "Grouping Type" toggle above the Custom Rules Scanner results, allowing reports to be viewed by Product (original behavior) or by the function/method containing each finding.
+
 ## 2.4.0
 * **Enhancement:** The Custom Rules Scanner now resolves array variables within the scanned code. It replaces placeholders like `{restricted_states}` in rule descriptions with a human-readable list of the actual states or postal codes, providing much richer context.
 

--- a/kiss-woo-shipping-settings-debugger.php
+++ b/kiss-woo-shipping-settings-debugger.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: KISS Woo Shipping Settings Debugger
  * Description: Exports UI-based WooCommerce shipping settings and scans theme files for custom shipping rules via AST.
- * Version:     2.4.0
+ * Version:     2.5.0
  * Author:      KISS Plugins
  * Requires at least: 6.0
  * Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- add Grouping Type toggle to switch between Product and Functional views
- group findings by containing function/method for Functional view
- bump version to 2.5.0 and document feature in changelog

## Testing
- `php -l scanner-trait.php`
- `php -l kiss-woo-shipping-settings-debugger.php`


------
https://chatgpt.com/codex/tasks/task_b_688ec9ff0e84832e91a0ef4b583e3d14